### PR TITLE
add originalCompetitors in week 4 exercise

### DIFF
--- a/week4/src/spread.ts
+++ b/week4/src/spread.ts
@@ -9,6 +9,7 @@ console.log(originalNumbers);
 // #2 Combining arrays
 export const winners = ['first'];
 export const runnerUps = ['second', 'third', 'fourth', 'fifth'];
+export const originalCompetitors = winners.concat(runnerUps)
 
 // refactor here
 


### PR DESCRIPTION
Hey @morgnism - I noticed the week 4 exercise was missing an "original" for the array combination piece with the winner/runners up. 

I used `concat` to create an `originalCompetitors` array for folks to check their work against.